### PR TITLE
fix(oauth2): add raw token response body

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,6 +23,5 @@ func GetToken(ctx context.Context, cfg oauth2.Config, h HandleAuthorizationRespo
 	if err != nil {
 		return nil, fmt.Errorf("poll token: %w", err)
 	}
-	oauth2Token := token.Token()
-	return &oauth2Token, nil
+	return token, nil
 }


### PR DESCRIPTION
This change adds access to the raw result, as oauth2.Token does. It's required to access e.g. the id_token, which is used by kubelog.

I would suggest to deprecate (or even remove?) `TokenResponse`, as it's now the same as `oauth2.Token` and does not really serve any other purpose anymore, what do you think @int128 ?